### PR TITLE
linting, default method values, and safer logging

### DIFF
--- a/pipedrive/__init__.py
+++ b/pipedrive/__init__.py
@@ -31,7 +31,7 @@ class Pipedrive(object):
         if method == "GET":
             uri = PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token)
             if data:
-                uri += urlencode(data)
+                uri += '&' + urlencode(data)
             response, data = self.http.request(uri, method=method, headers={'Content-Type': 'application/x-www-form-urlencoded'})
         else:
             uri = PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token)

--- a/pipedrive/__init__.py
+++ b/pipedrive/__init__.py
@@ -1,4 +1,5 @@
 from httplib2 import Http
+from logging import getLogger
 
 try:
     from urllib import urlencode
@@ -6,43 +7,54 @@ except ImportError:
     from urllib.parse import urlencode
 
 import json
-from copy import copy
 
 PIPEDRIVE_API_URL = "https://api.pipedrive.com/v1/"
+logger = getLogger('pipedrive')
+
 
 class PipedriveError(Exception):
     def __init__(self, response):
         self.response = response
+
     def __str__(self):
         return self.response.get('error', 'No error provided')
 
+
 class IncorrectLoginError(PipedriveError):
     pass
+
 
 class Pipedrive(object):
     def _request(self, endpoint, data, method='POST'):
         # avoid storing the string 'None' when a value is None
         data = {k: "" if v is None else v for k, v in data.items()}
         if method == "GET":
-            print('sending GET request to ' + PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token) + '&' + urlencode(data))
-            response, data = self.http.request(PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token) + '&' + urlencode(data), method=method, headers={'Content-Type': 'application/x-www-form-urlencoded'})
+            uri = PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token)
+            if data:
+                uri += urlencode(data)
+            response, data = self.http.request(uri, method=method, headers={'Content-Type': 'application/x-www-form-urlencoded'})
         else:
-            response, data = self.http.request(PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token), method=method, body=urlencode(data), headers={'Content-Type': 'application/x-www-form-urlencoded'})
-        
+            uri = PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token)
+            response, data = self.http.request(uri, method=method, body=urlencode(data), headers={'Content-Type': 'application/x-www-form-urlencoded'})
+
+        logger.debug('sending {method} request to {uri}'.format(
+            method=method,
+            uri=uri
+        ))
         # print(json.dumps(json.loads(data.decode('utf-8')), sort_keys=True, indent=4))
 
         # if python2, use:
         # return json.loads(data)
         return json.loads(data.decode('utf-8'))
 
-    def __init__(self, email, password = None):
+    def __init__(self, email, password=None):
         self.http = Http()
         if password:
             response = self._request("/authorizations/", {"email": email, "password": password})
 
             if 'error' in response:
                 raise IncorrectLoginError(response)
-            
+
             # self.api_token = response['authorization'][0]['api_token']
             self.api_token = response['data'][0]['api_token']
             print('api_token is ' + self.api_token)
@@ -51,7 +63,7 @@ class Pipedrive(object):
             self.api_token = email
 
     def __getattr__(self, name):
-        def wrapper(data, method):
+        def wrapper(data={}, method='GET'):
             response = self._request(name.replace('_', '/'), data, method)
             if 'error' in response:
                 raise PipedriveError(response)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='python-pipedrive',
-    version="0.3.1",
+    version="0.4.0",
     license="MIT",
 
-    install_requires = [
+    install_requires=[
         "httplib2",
     ],
 


### PR DESCRIPTION
Great library! I was basically about to write this myself but luckily did a google search first.

Because I'll be using it in a production environment, having the api token print to stdout was a bit of a red flag, but luckily it was easy to fix. I figured I'd push up those changes in case anyone else wanted some more control over logging.

My approach just uses the native `logging` module, and only print the full uri with the api key when you set up a logger to print DEBUG level logging events. You can test the approach with this code after setting PIPEDRIVE_API_KEY as an environment variable

```python
import logging
from pipedrive import Pipedrive
import os
import sys

root_logger = logging.getLogger()
stdout = logging.StreamHandler(sys.stdout)
root_logger.addHandler(stdout)
stdout.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))

PIPEDRIVE_API_KEY = os.environ.get('PIPEDRIVE_API_KEY')
pd = Pipedrive(PIPEDRIVE_API_KEY)

root_logger.setLevel(logging.DEBUG)
print('Calling API with log level DEBUG. Should see full uri')
pd.organizations()
print(' Success\n')

root_logger.setLevel(logging.INFO)
print('Calling API with log level INFO. Should not see any output')
pd.organizations()
print(' Success\n')
```

I also cleaned up the code to conform to PEP8 and added some default values to the request wrapper for ease of use.