### PR TITLE
Output as generator with lazy-loading pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pip-log.txt
 .mr.developer.cfg
 
 pipedrive/ve/
+
+__pycache__

--- a/pipedrive/__init__.py
+++ b/pipedrive/__init__.py
@@ -35,7 +35,7 @@ class Pipedrive(object):
             response, data = self.http.request(uri, method=method, headers={'Content-Type': 'application/x-www-form-urlencoded'})
         else:
             uri = PIPEDRIVE_API_URL + endpoint + '?api_token=' + str(self.api_token)
-            response, data = self.http.request(uri, method=method, body=urlencode(data), headers={'Content-Type': 'application/x-www-form-urlencoded'})
+            response, data = self.http.request(uri, method=method, body=json.dumps(data), headers={'Content-Type': 'application/json'})
 
         logger.debug('sending {method} request to {uri}'.format(
             method=method,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='python-pipedrive',
-    version="0.5.0",
+    version="0.5.1",
     license="MIT",
 
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='python-pipedrive',
-    version="0.4.0",
+    version="0.5.0",
     license="MIT",
 
     install_requires=[


### PR DESCRIPTION
This is a backward incompatible change to the way you use the pipedrive client, but I found it useful so I'm putting it up here for discussion.

Basically, I ended up writing a bunch of management code to get more than 100 things to handle pipedrive's pagination. Instead I really just wanted to write simple `for` loops over the results. So, I decided to change the wrapper into something that returned a python-style generator. The interface is quite nice for basic things, but if you rely on using `response['additional_data']` then that is now obscured.

tldr, you can now do this:
```python
pd = Pipedrive(PIPEDRIVE_API_TOKEN)

for person in pd.persons()
    # each person object is a dict representing the data on that person
    func(person)
```